### PR TITLE
Read halfmove clock and fullmove number from epd opening files

### DIFF
--- a/projects/lib/src/epdrecord.cpp
+++ b/projects/lib/src/epdrecord.cpp
@@ -44,8 +44,7 @@ bool EpdRecord::parse(QTextStream& stream)
 			return false;
 
 		m_fen.append(tmp);
-		if (i < 3)
-			m_fen.append(" ");
+		m_fen.append(" ");
 	}
 
 	// Parse the operations
@@ -62,6 +61,7 @@ bool EpdRecord::parse(QTextStream& stream)
 		switch (c.toLatin1())
 		{
 		case '\n':
+			appendMoveCounters();
 			return true;
 		case ' ':
 		case '\t':
@@ -133,8 +133,25 @@ bool EpdRecord::parse(QTextStream& stream)
 			return false;
 		}
 	}
-
+	appendMoveCounters();
 	return true;
+}
+
+void EpdRecord::appendMoveCounters()
+{
+	if (hasOpcode("hmvc") && m_operations.value("hmvc").length() > 0)
+		m_fen.append(m_operations.value("hmvc")[0]);
+
+	else
+		m_fen.append("0");
+
+	m_fen.append(" ");
+
+	if (hasOpcode("fmvn") && m_operations.value("fmvn").length() > 0)
+		m_fen.append(m_operations.value("fmvn")[0]);
+
+	else
+		m_fen.append("1");
 }
 
 bool EpdRecord::hasOpcode(const QString& opcode) const

--- a/projects/lib/src/epdrecord.h
+++ b/projects/lib/src/epdrecord.h
@@ -69,6 +69,7 @@ class LIB_EXPORT EpdRecord
 	private:
 		QString m_fen;
 		QMap<QString, QStringList> m_operations;
+		void appendMoveCounters();
 };
 
 #endif // EPDRECORD_H


### PR DESCRIPTION
A position in epd format doesn't store halfmove clock and fullmove number in the fen part, but they can still be specified (optionally) through the hmvc and fmvn opcodes. Use this when converting epd to fen.

As a side effect, if hmvc and fmvn are not set, we now return a fen with halfmove clock and fullmove number set to 0 and 1, since returning a fen without those is not strictly correct.